### PR TITLE
Update snapcraft.yaml for Flask 1.0 and core18

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: jakerye-learn-snapcraft-flask 
+base: core18
 version: '1.0.0'
 summary: Learn snapcraft with python flask app
 description: |
@@ -16,7 +17,9 @@ apps:
     plugs: [network-bind]
     environment:
       FLASK_APP: hello.py
-    
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+
 parts:
   flask-app:
     source: .


### PR DESCRIPTION
Flask 1.0 (Click) needs LC_ALL and LANG environment variables specified or it won't run. Adding base: core18 isn't required, but makes it current.